### PR TITLE
gnulib: Use https URL instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gnulib"]
 	path = .gnulib
-	url = git://git.sv.gnu.org/gnulib.git
+	url = https://git.savannah.gnu.org/git/gnulib.git


### PR DESCRIPTION
Matches upstream libguestfS commit [here](https://github.com/libguestfs/libguestfs/commit/b38e4eff2bec46de7976581ad0c73cf2fb6e73be).

This is apparently more secure (against MITM attacks), and furthermore Savannah git: access is broken at the moment.

